### PR TITLE
ci: update GHA actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   push_to_registry: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
 
@@ -50,9 +51,9 @@ jobs:
 
     steps:
       - name: Setup BATS
-        uses: mig4/setup-bats@v1
+        run: sudo npm install -g bats
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: test test-${{ matrix.version != '' && format('{0}-{1}',matrix.version, matrix.release) || format('{0}', matrix.release) }}
         run: make test VERSION=${{ matrix.version != '' && format('{0}-{1}',matrix.version, matrix.release) || format('{0}', matrix.release) }}
@@ -70,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to Packages Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -89,7 +90,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: ${{ env.push_to_registry }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
   getVersion:
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
       - name: Setup BATS
         run: sudo npm install -g bats
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: test test-${{ matrix.version != '' && format('{0}-{1}',matrix.version, matrix.release) || format('{0}', matrix.release) }}
         run: make test VERSION=${{ matrix.version != '' && format('{0}-{1}',matrix.version, matrix.release) || format('{0}', matrix.release) }}
@@ -68,7 +68,7 @@ jobs:
 
 #    if: ${{ github.event.release.published == true }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Login to Packages Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION

Bump checkout@v2→v4, login-action@v1→v3, build-push-action@v2→v6;
replace mig4/setup-bats@v1 with npm install; add
FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to silence remaining v4 warnings.
